### PR TITLE
Remove duplicate import of useNavigate in TaskManagement component

### DIFF
--- a/frontend/src/components/Pages/TaskManagement.js
+++ b/frontend/src/components/Pages/TaskManagement.js
@@ -10,7 +10,6 @@ import { Unity, useUnityContext } from "react-unity-webgl";
 import { UnityContainer, TaskWrapper } from "../Tasks/TaskViewer.styles";
 import { getAllTasks, deleteTask, uploadTaskFiles } from '../../services/taskService';
 import { showConfirmDialog, showSuccessAlert, showErrorAlert } from '../../utils/sweetAlert';
-import { useNavigate } from 'react-router-dom';
 import { debounce } from 'lodash';
 
 const TaskManagement = () => {


### PR DESCRIPTION
Eliminate error by removing the duplicate import statement for useNavigate in the TaskManagement component.