### PR TITLE
BF: Add endpoint to upload single WebGL file and enhance task deletion

### DIFF
--- a/backend/routes/taskRoute.js
+++ b/backend/routes/taskRoute.js
@@ -6,6 +6,7 @@ const fs = require('fs');
 const {
     createTask,
     uploadWebGLFiles,
+    uploadSingleWebGLFile,
     getAllTasks,
     getTaskById,
     updateTask,
@@ -42,6 +43,8 @@ router
 
 
 router.post('/:id/upload', authenticate, isAdmin, uploadWebGLFiles);
+
+router.post('/:id/upload/:fileType', authenticate, isAdmin, uploadSingleWebGLFile);
 
 // Route to assign a task to a course
 router.post('/:id/assign', authenticate, isTeacher, assignTaskToCourse);


### PR DESCRIPTION
This pull request introduces enhancements to WebGL file handling for tasks, including the ability to upload individual WebGL files, improved error handling, and cleanup of associated files during task deletion. Additionally, it updates the API routes to support these changes.

### WebGL File Handling Enhancements:
* **Added support for uploading individual WebGL files**: Created the `uploadSingleWebGLFile` method to handle uploading specific file types (`loader`, `data`, `framework`, `wasm`) with validation and cleanup of old files before upload.
* **Improved WebGL file cleanup during task deletion**: Ensured all associated WebGL files are deleted recursively when a task is deleted, with robust error handling for file operations.

### API Route Updates:
* **New route for uploading individual WebGL files**: Added the `POST /api/tasks/:id/upload-webgl/:fileType` route in `taskRoute.js` to support the new functionality.

### Task Deletion Improvements:
* **Enhanced success message for task deletion**: Updated the response message to reflect the deletion of both the task and its associated files.

### Code Cleanup:
* **Removed redundant validation in `getWebGLFiles`**: Simplified the method by removing unnecessary checks for file types and task existence, focusing on whether the file path exists.