### PR TITLE
Fix submission creation logic by ensuring task's submissions array is updated correctly

### DIFF
--- a/backend/controllers/submissionController.js
+++ b/backend/controllers/submissionController.js
@@ -54,6 +54,7 @@ exports.submitTask = asyncHandler(async (req, res) => {
     const isLate = new Date() > courseTask.dueDate;
     const status = isLate ? 'late' : 'submitted';
 
+
     const submission = await StudentSubmission.create({
         student: user._id,
         task: taskId,
@@ -61,6 +62,13 @@ exports.submitTask = asyncHandler(async (req, res) => {
         status: status,
         submittedAt: new Date(),
     });
+
+    // Update the task's submissions array
+    task.submissions.push(submission._id);
+
+    await task.save();
+
+    res.status(201).json(submission);
 });
 
 // @desc    Update a student submission


### PR DESCRIPTION
This pull request updates the `submitTask` function in `backend/controllers/submissionController.js` to ensure that a task's `submissions` array is updated whenever a new submission is created.

Key changes:

* [`backend/controllers/submissionController.js`](diffhunk://#diff-c4a61c85b2787eb8e2e7533b475169f7dfe92a1bb98fa376e505256ac0a3dd77R57-R71): Modified the `submitTask` function to push the newly created submission's ID to the task's `submissions` array and save the updated task.