### PR TITLE
BF: fix WebGL file paths in task deletion and upload functions

### DIFF
--- a/backend/controllers/taskController.js
+++ b/backend/controllers/taskController.js
@@ -436,13 +436,11 @@ exports.deleteTask = asyncHandler(async (req, res) => {
         throw new Error('Task not found');
     }
 
-    const taskName = task.title.toLowerCase().replace(/\s+/g, '-');
-
     // Delete WebGL files if they exist
     if (task.webglData && task.webglData.buildFolderPath) {
         try {
             // Determine base directory based on environment
-            const extractPath = path.join(__dirname, '../uploads/webgl', taskName);
+            const extractPath = path.join(__dirname, '../uploads/webgl', taskId);
 
             if (fs.existsSync(extractPath)) {
                 console.log(
@@ -462,7 +460,6 @@ exports.deleteTask = asyncHandler(async (req, res) => {
                 `Error deleting WebGL files for task ${taskId}:`,
                 error
             );
-            // Continue with task deletion even if file deletion fails
         }
     }
 
@@ -694,8 +691,7 @@ exports.uploadZipFile = asyncHandler(async (req, res) => {
     }
 
     const zipPath = req.file.path;
-    const taskName = task.title.toLowerCase().replace(/\s+/g, '-');
-    const extractPath = path.join(__dirname, '../uploads/webgl', taskName);
+    const extractPath = path.join(__dirname, '../uploads/webgl', taskId);
 
     // remove old build folder if it exists
     if (task.webglData.buildFolderPath && fs.existsSync(task.webglData.buildFolderPath)) {
@@ -709,10 +705,10 @@ exports.uploadZipFile = asyncHandler(async (req, res) => {
 
     task.webglData.buildFolderPath = extractPath;
     task.webglData.indexHtml = extractPath + '/index.html';
-    task.webglData.loader = extractPath + `/Build/${taskName}.loader.js`;
-    task.webglData.data = extractPath + `/Build/${taskName}.data`;
-    task.webglData.framework = extractPath + `/Framework/${taskName}.framework.js`;
-    task.webglData.wasm = extractPath + `/Build/${taskName}.wasm`;
+    task.webglData.loader = extractPath + `/Build/build.loader.js`;
+    task.webglData.data = extractPath + `/Build/build.data`;
+    task.webglData.framework = extractPath + `/Build/build.framework.js`;
+    task.webglData.wasm = extractPath + `/Build/build.wasm`;
 
     // Clean up the zip file after extraction
     fs.unlinkSync(zipPath);

--- a/frontend/src/components/Tasks/TaskViewer.js
+++ b/frontend/src/components/Tasks/TaskViewer.js
@@ -418,7 +418,7 @@ export default function TaskViewer() {
         }
 
         // Use the current window location protocol and host
-        var baseUrl = "http://localhost:3000/webgl/${cleanTitle}";
+        var baseUrl = "http://localhost:3000/webgl/${taskId}";
         var buildUrl = baseUrl + "/Build";
         var loaderUrl = buildUrl + "/build.loader.js";
         
@@ -432,7 +432,7 @@ export default function TaskViewer() {
             codeUrl: buildUrl + "/build.wasm",
             streamingAssetsUrl: baseUrl + "/StreamingAssets",
             companyName: "DefaultCompany",
-            productName: "${cleanTitle}",
+            productName: "${taskTitle}",
             productVersion: "1.0",
             showBanner: unityShowBanner,
         };


### PR DESCRIPTION
This pull request refactors the handling of WebGL file paths in both the backend and frontend to use `taskId` instead of dynamically generated names based on the task title. This change improves consistency and avoids potential issues with special characters or spaces in task titles.

### Backend Changes:
* Updated `deleteTask` and `uploadZipFile` methods in `backend/controllers/taskController.js` to use `taskId` for constructing WebGL file paths instead of relying on a transformed task title. This ensures paths are consistent and avoids errors caused by title formatting. [[1]](diffhunk://#diff-7fcce44f16ab9f11a4e17ccf277864868f4591e442ecf55bbf0627692a2d6248L439-R443) [[2]](diffhunk://#diff-7fcce44f16ab9f11a4e17ccf277864868f4591e442ecf55bbf0627692a2d6248L697-R694)
* Updated WebGL asset file names (e.g., `.loader.js`, `.data`, `.framework.js`, `.wasm`) to use a generic "build" prefix instead of the task name, simplifying file management.

### Frontend Changes:
* Modified `TaskViewer` in `frontend/src/components/Tasks/TaskViewer.js` to use `taskId` for constructing WebGL URLs, aligning with the backend changes.
* Updated the `productName` in the Unity loader configuration to use `taskTitle` instead of `cleanTitle`, ensuring the correct title is displayed.